### PR TITLE
Pkl jacob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,9 @@ cython_debug/
 # Ignore large MIST files
 MIST_v1.2_vvcrit0.0_basic_isos*
 ..bfg-report
+
+# Ignore pkl files
+*.pkl
+
+# Ignore the MACOS directory
+*__MACOS*

--- a/notebooks/prototyping.ipynb
+++ b/notebooks/prototyping.ipynb
@@ -16,8 +16,8 @@
     "\n",
     "# the isochrone data\n",
     "#!wget https://github.com/noahfranz13/astro-education-nbs/raw/refs/heads/main/isochrones.zip\n",
-    "#!unzip isochrones.zip\n",
-    "#update for the pickled file ... "
+    "!wget https://github.com/noahfranz13/astro-education-nbs/raw/refs/heads/main/data/isochrones.pkl.zip\n",
+    "!unzip isochrones.pkl.zip"
    ]
   },
   {

--- a/notebooks/prototyping.ipynb
+++ b/notebooks/prototyping.ipynb
@@ -15,8 +15,9 @@
     "!wget https://raw.githubusercontent.com/noahfranz13/astro-education-nbs/refs/heads/main/data/gaia_cone_search_results.csv\n",
     "\n",
     "# the isochrone data\n",
-    "!wget https://github.com/noahfranz13/astro-education-nbs/raw/refs/heads/main/isochrones.zip\n",
-    "!unzip isochrones.zip"
+    "#!wget https://github.com/noahfranz13/astro-education-nbs/raw/refs/heads/main/isochrones.zip\n",
+    "#!unzip isochrones.zip\n",
+    "#update for the pickled file ... "
    ]
   },
   {
@@ -418,18 +419,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 50,
    "metadata": {
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0      16.2439\n",
+      "1      15.4532\n",
+      "2      14.6225\n",
+      "3      13.8802\n",
+      "4      13.5291\n",
+      "        ...   \n",
+      "269     0.0810\n",
+      "270     0.0546\n",
+      "271     0.0293\n",
+      "272     0.0083\n",
+      "273    -0.0084\n",
+      "Name: u, Length: 274, dtype: object\n"
+     ]
+    }
+   ],
    "source": [
     "from util import read_isochrone_files\n",
+    "import pickle \n",
     "\n",
-    "isochrones = read_isochrone_files('../isochrones')"
+    "#old way from zip file\n",
+    "\"\"\"\n",
+    "isochrones = read_isochrone_files('../isochrones')\n",
+    "print(isochrones[1]['u'])\n",
+    "\n",
+    "#save the pickled object\n",
+    "with open(\"../data/isochrones.pkl\", \"wb\") as f:\n",
+    "    pickle.dump(isochrones, f)\n",
+    "\"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"../data/isochrones.pkl\", \"rb\") as f:\n",
+    "    isochrones = pickle.load(f)"
    ]
   },
   {

--- a/notebooks/prototyping.ipynb
+++ b/notebooks/prototyping.ipynb
@@ -572,8 +572,10 @@
     "label_turnoff(1,10,'AGB', color='blue')\n",
     "label_turnoff(0.1,-2,'WD', color='blue')\n",
     "\n",
-    "ax.plot(isochrones[-1]['g'].astype(float)-isochrones[-1]['r'].astype(float), isochrones[-1]['g'].astype(float))\n",
     "\n",
+    "\n",
+    "\n",
+    "ax.plot(isochrones[-1]['g'].astype(float)-isochrones[-1]['r'].astype(float), isochrones[-1]['g'].astype(float))\n",
     "plt.show()\n",
     "\n"
    ]


### PR DESCRIPTION
Hi Noah,

I pickled the isochrone file and changed the download url. The (zipped) pickle file is only 1 Mb larger than the isochrones.zip file we had previously tried to use. If unzipping is still an issue, the file is 80Mb uncompressed. I don't know how github would handle that. 

Happy holidays,
Jacob